### PR TITLE
Update gradle dependency to mobileapi 10.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "me.clarius.sdk.mobileapi.example"
@@ -36,12 +36,12 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-fragment:2.5.3'
     implementation 'androidx.navigation:navigation-ui:2.5.3'
     implementation 'androidx.preference:preference:1.2.0'
-    implementation 'me.clarius.sdk:mobileapi:10.1.0'
+    implementation 'me.clarius.sdk:mobileapi:10.1.1'
     implementation project(path: ':helper')
 }

--- a/helper/build.gradle
+++ b/helper/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
     defaultConfig {
         minSdk 26
         targetSdk 32
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation 'me.clarius.sdk:mobileapi:10.1.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'me.clarius.sdk:mobileapi:10.1.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
 }


### PR DESCRIPTION
**What does your change do?**

Bump up 'mobileapi' dependency '10.1.1’ in build.gradle files in both sub projects “helper” and “example”.
Bump up other android dependencies highlighted by Android Studio.